### PR TITLE
Stop after successful config load.

### DIFF
--- a/lib/bogo-config/config.rb
+++ b/lib/bogo-config/config.rb
@@ -180,19 +180,23 @@ module Bogo
       when '.rb' && eval_enabled?
         struct_load(file_path)
       else
-        result = [:struct_load, :json_load, :yaml_load, :xml_load].map do |loader|
+        result = nil
+
+        [:struct_load, :json_load, :yaml_load, :xml_load].each do |loader|
           begin
-            send(loader, file_path)
-          rescue StandardError, ScriptError => e
+            result = send(loader, file_path)
+            break
+          rescue MultiJson::ParseError, StandardError, ScriptError => e
             if(ENV['BOGO_DEBUG'])
               $stderr.puts "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
             end
-            nil
           end
-        end.compact.first
+        end
+
         unless(result)
           raise "Failed to load configuration from file (#{file_path})"
         end
+
         result
       end
     end


### PR DESCRIPTION
I was encountering a problem loading an AttributeSelect config file that did not have a `.rb` extension. The loader logic attempts to load it in every format, then compacts the resulting array and selects the first result. In my case, I this was resulting in `MultiJson::ParseError` since the Ruby based AttributeSelect was not able to be parsed as JSON.

This simple patch does a couple of things:
1. Rather than mapping over available config formats, use each and break after a successful result is generated. This keeps us from having to parse configuration files when we're just going to discard the return values (almost certainly nil, since the parses are going to fail anyway) and use the first successful result.
2. Catch MultiJson parse errors and provide diagnostic info if BOGO_DEBUG is set.
