### PR TITLE
Fix redefinition warnings

### DIFF
--- a/lib/bogo/config.rb
+++ b/lib/bogo/config.rb
@@ -153,7 +153,7 @@ module Bogo
     end
 
     # Allow Smash like behavior
-    def_delegators *([:data, :[]] + (Smash.public_instance_methods - Object.public_instance_methods))
+    def_delegators(*([:data] + (Smash.public_instance_methods - Object.public_instance_methods)))
 
     # Override to force consistent data access (removes dirty
     # functionality)

--- a/test/specs/config_json_spec.rb
+++ b/test/specs/config_json_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../spec'
 
 describe Bogo::Config do
-
   describe 'JSON files' do
     before do
       @config = Bogo::Config.new(File.join(File.dirname(__FILE__), 'json'))
@@ -10,16 +9,14 @@ describe Bogo::Config do
     let(:config){ @config }
 
     it 'should provide valid config' do
-      config.get(:base, :fubar, :feebar).must_equal true
+      _(config.get(:base, :fubar, :feebar)).must_equal true
     end
 
     it 'should merge files in sorted order' do
-      config.get(:base, :bang).must_equal 'boom'
-      config.get(:base, :blam).must_equal false
-      config.get(:base, :fubar, :complete).must_equal 3.0
-      config[:last_file].must_equal true
+      _(config.get(:base, :bang)).must_equal 'boom'
+      _(config.get(:base, :blam)).must_equal false
+      _(config.get(:base, :fubar, :complete)).must_equal 3.0
+      _(config[:last_file]).must_equal true
     end
-
   end
-
 end

--- a/test/specs/config_mix_files_spec.rb
+++ b/test/specs/config_mix_files_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../spec'
 
 describe Bogo::Config do
-
   describe 'Mixed files' do
     before do
       @config = Bogo::Config.new(File.join(File.dirname(__FILE__), 'mixed'))
@@ -10,16 +9,14 @@ describe Bogo::Config do
     let(:config){ @config }
 
     it 'should provide valid config' do
-      config.get(:base, :fubar, :feebar).must_equal true
+      _(config.get(:base, :fubar, :feebar)).must_equal true
     end
 
     it 'should merge files in sorted order' do
-      config.get(:base, :bang).must_equal 'boom'
-      config.get(:base, :blam).must_equal false
-      config.get(:base, :fubar, :complete).must_equal 3.0
-      config[:last_file].must_equal true
+      _(config.get(:base, :bang)).must_equal 'boom'
+      _(config.get(:base, :blam)).must_equal false
+      _(config.get(:base, :fubar, :complete)).must_equal 3.0
+      _(config[:last_file]).must_equal true
     end
-
   end
-
 end

--- a/test/specs/config_spec.rb
+++ b/test/specs/config_spec.rb
@@ -7,7 +7,6 @@ class MyConfig < Bogo::Config
 end
 
 describe Bogo::Config do
-
   before do
     @config = MyConfig.new(
       :name => 'custom config',
@@ -22,43 +21,42 @@ describe Bogo::Config do
   let(:config){ @config }
 
   it 'should allow unconfigured config' do
-    Bogo::Config.new.path.must_equal nil
+    _(Bogo::Config.new.path).must_be_nil
   end
 
   it 'should have customized name' do
-    config.name.must_equal 'custom config'
+    _(config.name).must_equal 'custom config'
   end
 
   it 'should have a count of 1' do
-    config.count.must_equal 1
+    _(config.count).must_equal 1
   end
 
   it 'should have a location of type Smash' do
-    config.location.class.must_equal Smash
+    _(config.location.class).must_equal Smash
   end
 
   it 'should error if no count is provided' do
-    ->{ MyConfig.new(:name => 'custom config') }.must_raise(ArgumentError)
+    _{ MyConfig.new(:name => 'custom config') }.must_raise(ArgumentError)
   end
 
   it 'should allow updating defined attributes' do
     config.name = 'fubar'
-    config.name.must_equal 'fubar'
+    _(config.name).must_equal 'fubar'
   end
 
   it 'should allow free form access' do
     my_conf = Bogo::Config.new(:a => 1, :b => 2, :c => {:d => {:e => 3}})
-    my_conf[:a].must_equal 1
-    my_conf.get(:b).must_equal 2
-    my_conf.get(:c, :d, :e).must_equal 3
-    my_conf.fetch(:z, :c, :x, 4).must_equal 4
+    _(my_conf[:a]).must_equal 1
+    _(my_conf.get(:b)).must_equal 2
+    _(my_conf.get(:c, :d, :e)).must_equal 3
+    _(my_conf.fetch(:z, :c, :x, 4)).must_equal 4
   end
 
   it 'should allow option immutable' do
     my_conf = Bogo::Config.new(:a => 1, :b => 2, :c => {:d => {:e => 3}})
     my_conf.immutable!
-    my_conf[:a].must_be :frozen?
-    my_conf[:c][:d].must_be :frozen?
+    _(my_conf[:a]).must_be :frozen?
+    _(my_conf[:c][:d]).must_be :frozen?
   end
-
 end

--- a/test/specs/config_struct_spec.rb
+++ b/test/specs/config_struct_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../spec'
 
 describe Bogo::Config do
-
   describe 'AttributeStruct files' do
     before do
       @config = Bogo::Config.new(File.join(File.dirname(__FILE__), 'struct'))
@@ -10,16 +9,14 @@ describe Bogo::Config do
     let(:config){ @config }
 
     it 'should provide valid config' do
-      config.get(:base, :fubar, :feebar).must_equal true
+      _(config.get(:base, :fubar, :feebar)).must_equal true
     end
 
     it 'should merge files in sorted order' do
-      config.get(:base, :bang).must_equal 'boom'
-      config.get(:base, :blam).must_equal false
-      config.get(:base, :fubar, :complete).must_equal 3.0
-      config[:last_file].must_equal true
+      _(config.get(:base, :bang)).must_equal 'boom'
+      _(config.get(:base, :blam)).must_equal false
+      _(config.get(:base, :fubar, :complete)).must_equal 3.0
+      _(config[:last_file]).must_equal true
     end
-
   end
-
 end

--- a/test/specs/config_xml_spec.rb
+++ b/test/specs/config_xml_spec.rb
@@ -10,16 +10,15 @@ describe Bogo::Config do
     let(:config){ @config }
 
     it 'should provide valid config' do
-      config.get(:base, :fubar, :feebar).must_equal true
+      _(config.get(:base, :fubar, :feebar)).must_equal true
     end
 
     it 'should merge files in sorted order' do
-      config.get(:base, :bang).must_equal 'boom'
-      config.get(:base, :blam).must_equal false
-      config.get(:base, :fubar, :complete).must_equal 3.0
-      config[:last_file].must_equal true
+      _(config.get(:base, :bang)).must_equal 'boom'
+      _(config.get(:base, :blam)).must_equal false
+      _(config.get(:base, :fubar, :complete)).must_equal 3.0
+      _(config[:last_file]).must_equal true
     end
 
   end
-
 end

--- a/test/specs/config_yaml_spec.rb
+++ b/test/specs/config_yaml_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../spec'
 
 describe Bogo::Config do
-
   describe 'YAML files' do
     before do
       @config = Bogo::Config.new(File.join(File.dirname(__FILE__), 'yaml'))
@@ -10,16 +9,14 @@ describe Bogo::Config do
     let(:config){ @config }
 
     it 'should provide valid config' do
-      config.get(:base, :fubar, :feebar).must_equal true
+      _(config.get(:base, :fubar, :feebar)).must_equal true
     end
 
     it 'should merge files in sorted order' do
-      config.get(:base, :bang).must_equal 'boom'
-      config.get(:base, :blam).must_equal false
-      config.get(:base, :fubar, :complete).must_equal 3.0
-      config[:last_file].must_equal true
+      _(config.get(:base, :bang)).must_equal 'boom'
+      _(config.get(:base, :blam)).must_equal false
+      _(config.get(:base, :fubar, :complete)).must_equal 3.0
+      _(config[:last_file]).must_equal true
     end
-
   end
-
 end

--- a/test/specs/load_fail_spec.rb
+++ b/test/specs/load_fail_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../spec'
 
 describe Bogo::Config do
-
   def with_env(k,v)
     old, ENV[k] = ENV[k], v
     yield
@@ -17,15 +16,14 @@ describe Bogo::Config do
         Bogo::Config.new(File.join(config_dir, 'config-ruby'))
       end
     end
-    e.original.message.must_equal "Ruby based configuration evaluation is currently disabled!"
+    _(e.original.message).must_equal "Ruby based configuration evaluation is currently disabled!"
   end
 
   describe 'File load failure' do
-
     let(:config_path){ File.join(config_dir, 'config.json') }
 
     it 'should generate a custom exception on load failure' do
-      ->{
+      _{
         Bogo::Config.new(config_path)
       }.must_raise Bogo::Config::FileLoadError
     end
@@ -36,8 +34,8 @@ describe Bogo::Config do
         Bogo::Config.new(config_path)
       rescue Bogo::Config::FileLoadError => error
       end
-      error.must_be_kind_of Bogo::Config::FileLoadError
-      error.original.must_be_kind_of Exception
+      _(error).must_be_kind_of Bogo::Config::FileLoadError
+      _(error.original).must_be_kind_of Exception
     end
 
     it 'should provide customer errors for ruby' do
@@ -45,18 +43,16 @@ describe Bogo::Config do
         Bogo::Config.new(File.join(config_dir, 'config.rb'))
       end
     end
-
   end
 
   describe 'Extensionless load error' do
-
     it 'should provide ruby exception on ruby file' do
       error = nil
       begin
         Bogo::Config.new(File.join(config_dir, 'config-ruby'))
       rescue Bogo::Config::FileLoadError => error
       end
-      error.original.must_be_kind_of SyntaxError
+      _(error.original).must_be_kind_of SyntaxError
     end
 
     it 'should provide json exception on json file' do
@@ -65,7 +61,7 @@ describe Bogo::Config do
         Bogo::Config.new(File.join(config_dir, 'config-json'))
       rescue Bogo::Config::FileLoadError => error
       end
-      error.original.must_be_kind_of MultiJson::ParseError
+      _(error.original).must_be_kind_of MultiJson::ParseError
     end
 
     it 'should provide yaml exception on yaml file' do
@@ -74,7 +70,7 @@ describe Bogo::Config do
         Bogo::Config.new(File.join(config_dir, 'config-yaml'))
       rescue Bogo::Config::FileLoadError => error
       end
-      error.original.must_be_kind_of Psych::SyntaxError
+      _(error.original).must_be_kind_of Psych::SyntaxError
     end
 
     it 'should provide xml exception on xml file' do
@@ -83,9 +79,7 @@ describe Bogo::Config do
         Bogo::Config.new(File.join(config_dir, 'config-xml'))
       rescue Bogo::Config::FileLoadError => error
       end
-      error.original.must_be_kind_of MultiXml::ParseError
+      _(error.original).must_be_kind_of MultiXml::ParseError
     end
-
   end
-
 end


### PR DESCRIPTION
Prevent redefinition warnings when setting
up method delegation.
