### PR TITLE
Add kernelify support to configuration structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,45 @@ Configuration.new do
 end
 ```
 
+#### Kernel methods
+
+By default the configuration is loaded within a mostly
+empty context and does not include commonly expected
+methods as defined by the `Kernel` module. There are 
+two ways access these methods:
+
+##### Use root namespace
+
+Accessing methods on the `Kernel` module can be accomplished
+by forcing the root namespace:
+
+``` ruby
+Configuration.new do
+  random_value ::Kernel.rand
+end
+```
+
+##### Load within kernelified struct
+
+Methods from the `Kernel` module can be made available within
+the struct when loading the configuration:
+
+``` ruby
+config = MyConfig.new('/tmp/bogo-config.rb', :kernelify)
+```
+
+This will allow using the `Kernel` module methods directly:
+
+``` ruby
+Configuration.new do
+  random_value rand
+end
+```
+
+__NOTE__: Use caution when using `:kernelify`. Because it 
+makes all methods defined on the `Kernel` module available,
+it may conflict with desired attribute names._
+
 ### Configuration file support
 
 Currently the following serialization types are supported:

--- a/lib/bogo/config.rb
+++ b/lib/bogo/config.rb
@@ -105,15 +105,18 @@ module Bogo
     attr_reader :path
     # @return [String, Hash]
     attr_reader :initial
+    # @return [TrueClass, FalseClass]
+    attr_reader :kernelify
 
     # Create new instance
     #
     # @param path_or_hash [String, Hash] file/directory path or base Hash
     # @return [self]
-    def initialize(path_or_hash=nil)
+    def initialize(path_or_hash=nil, kernelify=false)
       super()
       @initial = path_or_hash
       @data = Smash.new
+      @kernelify = !!kernelify
       init!
     end
 
@@ -300,7 +303,10 @@ module Bogo
         result = Module.new.instance_eval(
           IO.read(file_path), file_path, 1
         )
-        result._dump.to_smash
+        struct = AttributeStruct.new
+        struct.kernelify! if kernelify
+        struct._build(&result.block)
+        struct._dump.to_smash
       end
     end
 

--- a/lib/bogo/config/configuration.rb
+++ b/lib/bogo/config/configuration.rb
@@ -1,5 +1,6 @@
-require 'bogo-config'
-require 'attribute_struct'
-
-class Configuration < AttributeStruct
+class Configuration
+  attr_reader :block
+  def initialize(&block)
+    @block = block
+  end
 end

--- a/test/specs/config_struct_spec.rb
+++ b/test/specs/config_struct_spec.rb
@@ -18,5 +18,25 @@ describe Bogo::Config do
       expect(config.get(:base, :fubar, :complete)).to eq(3.0)
       expect(config[:last_file]).to be_truthy
     end
+
+    context "kernelified" do
+      before do
+        @config = Bogo::Config.new(File.join(File.dirname(__FILE__), 'struct-kernelify'), :kernelify)
+      end
+
+      let(:config){ @config }
+
+      it 'should provide valid config' do
+        expect(config.get(:base, :fubar, :feebar)).to be_truthy
+      end
+
+      it 'should merge files in sorted order' do
+        expect(config.get(:base, :bang)).to eq('boom')
+        expect(config.get(:base, :blam)).to be_falsey
+        expect(config.get(:base, :fubar, :complete)).to eq(3.0)
+        expect(config[:last_file]).to be_truthy
+        expect(config[:kernel_test]).to be_a(Float)
+      end
+    end
   end
 end

--- a/test/specs/struct-kernelify/00_base.rb
+++ b/test/specs/struct-kernelify/00_base.rb
@@ -1,0 +1,5 @@
+Configuration.new do
+  base.fubar.feebar true
+  base.bang 'boom'
+  blam 3
+end

--- a/test/specs/struct-kernelify/01_fubar.rb
+++ b/test/specs/struct-kernelify/01_fubar.rb
@@ -1,0 +1,4 @@
+Configuration.new do
+  fubar 'hi'
+  base.blam false
+end

--- a/test/specs/struct-kernelify/02_last.rb
+++ b/test/specs/struct-kernelify/02_last.rb
@@ -1,0 +1,5 @@
+Configuration.new do
+  last_file true
+  base.fubar.complete 3.0
+  kernel_test rand
+end


### PR DESCRIPTION
Allow enabling kernelify support on attribute struct used for
configuration loading. This will make methods defined on the
`Kernel` module available to the configuration.

Fixes #3 